### PR TITLE
Updated React Version

### DIFF
--- a/react-app/package.json
+++ b/react-app/package.json
@@ -12,7 +12,7 @@
     "date-fns": "^2.13.0",
     "http-proxy-middleware": "^1.0.5",
     "immer": "^8.0.1",
-    "react": "^16.14.0",
+    "react": "^17.0.1",
     "react-dom": "^16.14.0",
     "react-geocode": "^0.2.3",
     "react-hamburger-menu": "^1.2.1",


### PR DESCRIPTION
- Updated React Version to 17 because React Google Maps API requires React 16.6 or later to run effectively 
- Pull and run npm install in React